### PR TITLE
added spock as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spock-example"]
+	path = spock-example
+	url = ./spock-example

--- a/pom.xml
+++ b/pom.xml
@@ -538,6 +538,7 @@
 		<module>persistence</module>
 		<module>services</module>
 		<module>app</module>
+                <module>spock-example</module>
 	</modules>
 
 </project>


### PR DESCRIPTION
Added spock examples as submodule with branch vprusa-test 
https://github.com/vprusa/spock-example/tree/vprusa-test
I was not successful with configuring the module for IDEA in such a way that would add syntax, package, highlighting, etc. support to the IDE.. 
For me language such as groovy not supported in IDE is a big blocker.
I need to get back to that. It is possible that there is some additonal configuraton necessary or that not using gradle together with maven but on its own would solve something. or maybe just the spock-examples is not sufficient enough for this.